### PR TITLE
Fixed an incorrect hyperlink.

### DIFF
--- a/_pages/overview.md
+++ b/_pages/overview.md
@@ -35,7 +35,7 @@ feature_row3:
     alt: "solution strategy overview"
     title: "3. Context and Scope"
     excerpt: 'Delimits your system from its (external) communication partners (neighboring systems and users). Specifies the external interfaces. Shown from a business/domain perspective (always) or a technical perspective (optional)'
-    url: "http://docs.arc42.org/section-4/"
+    url: "http://docs.arc42.org/section-3/"
     btn_label: "Read More"
     btn_class: "btn--inverse"    
 


### PR DESCRIPTION
I found an incorrect hyperlink ... the "Context and Scope" link on the overview page takes you to the "Solution Strategy" page.