### PR TITLE
Fix a typo

### DIFF
--- a/_pages/examples.md
+++ b/_pages/examples.md
@@ -35,7 +35,7 @@ feature_row1:
 Here you find links to public arc42 examples. Contact us if you like your system
 included here...
 
-[HTML Sanity Checker](https://hsc.aim42.org) (Englisch)  
+[HTML Sanity Checker](https://hsc.aim42.org) (English)  
 Verbose example for the documentation of a Gradle plugin, created by Dr. Gernot Starke.
 
 [DocChess](http://www.dokchess.de/dokchess/arc42/) (German)  


### PR DESCRIPTION
Fixed a typo.

In addition, I am not sure how this is part of this project or not, but you should rework https://hsc.aim42.org/ because there is a mix between the new and the old template of the [docToolchain](https://github.com/docToolchain/docToolchain).

All pages are like "This page shall contain" and sometimes you can jump to the old page (that looks like the default Asciidoctor rendering)

I mean this is your first example in English. Most of the reader will click on the link as I did (and might be disappointed)
