### PR TITLE
Fix link to docToolchain in download.md

### DIFF
--- a/_pages/download.md
+++ b/_pages/download.md
@@ -248,7 +248,7 @@ Please [contact us!](/contact)
 
 **asciidoc**
 : Powerful yet simple markup language, used by arc42 itself. Ideally suited for architecture documentation. See
-[docToolchain](https://rdmueller.github.io/docToolchain/) or the [original source](https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/).
+[docToolchain](https://doctoolchain.github.io/docToolchain/) or the [original source](https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/).
 
 **markdown**
 : Widespread and simple markup language, [documented here](https://daringfireball.net/projects/markdown/syntax) by its inventor.


### PR DESCRIPTION
This PR updates the `docToolchain` [reference link](https://doctoolchain.github.io/docToolchain/) in the documentation section.

**Details**
	•	Replaces the outdated URL (`rdmueller.github.io`) with the current official repository location (`doctoolchain.github.io`).
	•	Keeps the reference aligned with the actively maintained upstream project.
	•	No functional or structural changes to the documentation –this is purely a link correction.